### PR TITLE
#12 Feature: Create, read and delete **Assignment** (assign driver to bus )

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11634,6 +11634,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/openapi-types": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+            "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/optionator": {
             "version": "0.8.3",
             "license": "MIT",
@@ -17846,7 +17853,8 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-babel/-/nyc-config-babel-3.0.0.tgz",
             "integrity": "sha512-mPnSPXfTRWCzYsT64PnuPlce6/hGMCdVVMgU2FenXipbUd+FDwUlqlTihXxpxWzcNVOp8M+L1t/kIcgoC8A7hg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@istanbuljs/schema": {
             "version": "0.1.3",
@@ -18565,7 +18573,8 @@
         },
         "acorn-jsx": {
             "version": "5.3.2",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -22381,7 +22390,8 @@
         },
         "jest-pnp-resolver": {
             "version": "1.2.2",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "jest-regex-util": {
             "version": "27.5.1",
@@ -24395,6 +24405,13 @@
                 "mimic-fn": "^2.1.0"
             }
         },
+        "openapi-types": {
+            "version": "12.0.0",
+            "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+            "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
+            "dev": true,
+            "peer": true
+        },
         "optionator": {
             "version": "0.8.3",
             "requires": {
@@ -24720,7 +24737,8 @@
             "version": "1.0.1"
         },
         "pg-pool": {
-            "version": "3.5.1"
+            "version": "3.5.1",
+            "requires": {}
         },
         "pg-protocol": {
             "version": "1.5.0"
@@ -27772,7 +27790,8 @@
         },
         "ws": {
             "version": "7.5.8",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xdg-basedir": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "start:dev": "cross-env NODE_ENV=dev nodemon --exec babel-node src/index.js",
         "start": "cross-env NODE_ENV=prod node dist/index.js",
         "dev": "nodemon -L --exec babel-node src/index.js",
-        "test": "cross-env NODE_ENV=test nyc mocha './src/**/*.test.js' --require @babel/register --recursive  --exit --timeout 30000",
+        "test": "cross-env NODE_ENV=test nyc mocha './src/**/*.test.js' --require @babel/register --recursive  --exit --timeout 50000",
         "build": "babel src --out-dir dist",
         "seed": "npx sequelize-cli db:seed:all",
         "down": "npx sequelize-cli db:migrate:undo:all",

--- a/src/Controllers/assign.driver.to.buses.controller.js
+++ b/src/Controllers/assign.driver.to.buses.controller.js
@@ -1,0 +1,57 @@
+import pool from "../Database/database";
+import { assignValidation } from "../validations/index";
+
+export const getAllAssigned = async (req, res) => {
+  const routes = await pool.query(
+    "SELECT * FROM Driver_buse_assign ORDER BY id ASC"
+  );
+  res.status(200).json({
+    status: res.__("status0"),
+    results: routes.rowCount,
+    assigned: routes.rows,
+  });
+};
+
+export const createAssign = async (req, res) => {
+  try {
+    const { error } = assignValidation(req.body);
+    if (error) {
+      return res.status(400).send({ message: error.details[0].message });
+    }
+    const { route, driver_name, plate_number } = req.body;
+    const assigned = await pool.query(
+      "INSERT INTO Driver_buse_assign (route, driver_name, plate_number) VALUES ($1, $2, $3) RETURNING *",
+      [route, driver_name, plate_number]
+    );
+    res.status(201).json({
+      status: res.__("status2"),
+      route: assigned.rows,
+    });
+  } catch (e) {
+    res.status(404).json({
+      status: "fail",
+      message: e.detail,
+    });
+  }
+};
+
+export const deleteAssigned = async (req, res) => {
+  try {
+    await pool.query(
+      `SELECT * FROM Driver_buse_assign where id = ${req.params.id} `
+    );
+    const deleted = await pool.query(
+      "DELETE FROM Driver_buse_assign WHERE id = $1",
+      [req.params.id]
+    );
+
+    res.status(202).json({
+      status: res.__("status4"),
+      message: "Route deleted successfully",
+    });
+  } catch (e) {
+    res.status(404).json({
+      status: "fail",
+    });
+  }
+};

--- a/src/Controllers/assign.driver.to.buses.controller.js
+++ b/src/Controllers/assign.driver.to.buses.controller.js
@@ -1,0 +1,51 @@
+import pool from "../Database/database";
+import { assignValidation } from "../validations/index";
+
+export const getAllAssigned = async (req, res) => {
+  const routes = await pool.query(
+    "SELECT * FROM Driver_buse_assign ORDER BY id ASC"
+  );
+  res.status(200).json({
+    status: res.__("status0"),
+    results: routes.rowCount,
+    assigned: routes.rows,
+  });
+};
+
+export const createAssign = async (req, res) => {
+  try {
+    const { error } = assignValidation(req.body);
+    if (error) {
+      return res.status(400).send({ message: error.details[0].message });
+    }
+    const { route, driver_name, plate_number } = req.body;
+    const assigned = await pool.query(
+      "INSERT INTO Driver_buse_assign (route, driver_name, plate_number) VALUES ($1, $2, $3) RETURNING *",
+      [route, driver_name, plate_number]
+    );
+    res.status(201).json({
+      status: res.__("status2"),
+      route: assigned.rows,
+    });
+  } catch (e) {
+    res.status(404).json({
+      status: "fail",
+      message: e.detail,
+    });
+  }
+};
+
+export const deleteAssigned = async (req, res) => {
+    await pool.query(
+      `SELECT * FROM Driver_buse_assign where id = ${req.params.id} `
+    );
+    const deleted = await pool.query(
+      "DELETE FROM Driver_buse_assign WHERE id = $1",
+      [req.params.id]
+    );
+
+    res.status(202).json({
+      status: res.__("status4"),
+      message: "Route deleted successfully",
+    });
+};

--- a/src/Database/database.js
+++ b/src/Database/database.js
@@ -1,10 +1,22 @@
 import { Pool } from "pg";
 
- const pool = new Pool({
-    host: "localhost",
-    user: "postgres",
-    port: "5432",
-    password: "andela123",
-    database: "postgres"
-})
-export default pool
+const pool = new Pool({
+  host: "localhost",
+  user: "postgres",
+  port: "5432",
+  password: "lucifer",
+  database: "postgres",
+});
+
+// function to precreate table if not exists
+const createTable = async () => {
+  await pool.query(
+    "CREATE TABLE IF NOT EXISTS Driver_buse_assign ( route VARCHAR(40), driver_name VARCHAR(40), plate_number VARCHAR(120), id SERIAL, PRIMARY KEY ( plate_number ) )"
+  );
+  await pool.query(
+    "CREATE TABLE IF NOT EXISTS Routes (origin VARCHAR(40), destination VARCHAR(40), description VARCHAR(120), id SERIAL, PRIMARY KEY ( origin, destination ) )"
+  );
+};
+createTable();
+
+export default pool;

--- a/src/Routes/driver.bus.assign.route.js
+++ b/src/Routes/driver.bus.assign.route.js
@@ -1,0 +1,14 @@
+import express from "express";
+import {
+  getAllAssigned,
+  createAssign,
+  deleteAssigned
+} from "../Controllers/assign.driver.to.buses.controller";
+
+const router = express.Router();
+
+router.get("/", getAllAssigned);
+router.post("/", createAssign);
+router.delete("/:id", deleteAssigned);
+
+export default router;

--- a/src/Routes/driver.bus.assign.route.js
+++ b/src/Routes/driver.bus.assign.route.js
@@ -1,0 +1,15 @@
+import express from "express";
+import {
+  getAllAssigned,
+  createAssign,
+  deleteAssigned
+} from "../Controllers/assign.driver.to.buses.controller";
+import nodemailerConfig from "../middleware/nodemailer.config"
+
+const router = express.Router();
+
+router.get("/", getAllAssigned);
+router.post("/", nodemailerConfig, createAssign);
+router.delete("/:id", nodemailerConfig, deleteAssigned);
+
+export default router;

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ import driverRouter from './Routes/driver.route';
 import signInRouter from "./Routes/signin.route";
 import logOutRouter from "./routes/logout.route"
 import routesCrudRouter from "./Routes/routes.route"
+import assignedRouter from "./Routes/driver.bus.assign.route"
 import busRouter from "./Routes/bus.route";
 import cors from "cors";
 import authroutes from "./Routes/auth.route"
@@ -40,6 +41,7 @@ server.use("/api/v1/profile", profileRouter);
 server.use("/api/v1/auth", signInRouter);
 server.use("/api/v1/auth", logOutRouter);
 server.use("/api/v1/route", routesCrudRouter);
+server.use("/api/v1/assign", assignedRouter);
 
 server.use("/api/v1/bus", busRouter);
 server.use('/api/v1', authroutes)

--- a/src/middleware/nodemailer.config.js
+++ b/src/middleware/nodemailer.config.js
@@ -1,0 +1,68 @@
+import nodemailer from "nodemailer";
+import pool from "../Database/database";
+
+// the middleware used to send email to the driver when assingment or unassignment happen to him.
+// =============================================================================================
+const nodemailerConfigMiddleware = async (req, res, next) => {
+  //the default message to be sent declaration
+  let notifyingMessage = "";
+  let assignMessage = "";
+  // destructure the method from request object
+  const { method } = req;
+
+  const transporter = nodemailer.createTransport({
+    // server used by outlook short mail transport protocol (smtp) is called "hotmail"
+    service: "hotmail",
+    // the custom user account created at the outlook to act as a sender to any accounts else, either gmail or other.
+    //  for testing the functionality of  nodemailer
+    auth: {
+      user: "phantomu2022@outlook.com",
+      pass: "Phantompassword1@",
+    },
+  });
+  const mailOptions = {
+    from: "phantomu2022@outlook.com",
+    to: "testphantomapp@gmail.com",
+    subject: `Driver ${assignMessage} status`,
+    html: notifyingMessage,
+  };
+  //try sending an email using sendMail method on the transporter.
+  try {
+    if (method === "DELETE") {
+      // Find user going to be deleted and parse his information along with the message going to be send on the email
+      const wasUser = await pool.query(
+        `SELECT * FROM Driver_buse_assign where id = ${req.params.id} `
+      );
+      const dataToBedeleted = wasUser.rows[0];
+      const { plate_number, driver_name } = dataToBedeleted;
+      notifyingMessage = `Dear ${driver_name}, <br><br>You are <u> REMOVED to driving </u> a car with plate number: <strong> ${plate_number}. </strong> <br><br>Thank you!`;
+      assignMessage = "UNASSIGNMENT";
+      // for post capture data submitted and use them to build the message to send in the email of driver as notification.
+    } else if (method === "POST") {
+      const { plate_number, driver_name } = req.body;
+      if (
+        plate_number === "" ||
+        plate_number === " " ||
+        driver_name === "" ||
+        driver_name === " "
+      ) {
+         next();
+      }
+        notifyingMessage = `Dear ${driver_name}, <br><br>You are <u> ASSIGNED to driving </u> a car with plate number:<strong> ${plate_number}.  </strong> <br><br>Thank you!`;
+      assignMessage = "ASSIGNMENT";
+    }
+    const info = await transporter.sendMail(mailOptions);
+    console.log("Good, It sent!!\nStatus Message: \n" + info.response);
+    next();
+    // if sending fail for some reason, catch that error.
+  } catch (error) {
+    res
+      .status(404)
+      .json({
+        message: "fail to send email on the nodemailer application",
+        status: "fail",
+      });
+  }
+};
+
+export default nodemailerConfigMiddleware;

--- a/src/tests/assign.driver.buses.test.js
+++ b/src/tests/assign.driver.buses.test.js
@@ -1,0 +1,118 @@
+/** @format */
+import index from "../app";
+import chai, { expect } from "chai";
+import chaiHttp from "chai-http";
+
+chai.use(chaiHttp);
+
+
+describe("delete all before testing", () => {});
+describe("POST API /api/v1/assign/", () => {
+  const assign2 = {
+    route: "karuruma - kimironko",
+    driver_name: "Sylvain Niyonkuru",
+    plate_number: "RAD 23480 B",
+  };
+
+  it("Should return Assign validation when empty data entry in entered", (done) => {
+    const fakeAssign = {
+      route: "",
+      driver_name: "",
+      plate_number: "",
+    };
+    chai
+      .request(index)
+      .post("/api/v1/assign/")
+      .send(fakeAssign)
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res).to.have.status([400]);
+        expect(res.body).to.have.property("message");
+        return done();
+      });
+  });
+  it("Should check duplicate assigns created", (done) => {
+    chai
+      .request(index)
+      .post("/api/v1/assign/")
+      .send(assign2)
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res).to.have.status([404]);
+        expect(res.body).to.have.property("status");
+        expect(res.body).to.have.property("message");
+        return done();
+      });
+  });
+   it("Should be able to create the assign and delete the assign", function (done) {
+      const assign = {
+        route: "kayonza - nyandungu",
+        driver_name: "Aimable Nyagahungu",
+        plate_number: " RAD 239342 B",
+      };
+     chai
+       .request(index)
+       .post("/api/v1/assign/")
+       .send(assign)
+       .end((err, res) => {
+         if (err) return done(err);
+         expect(res).to.have.status(201);
+         expect(res.body).to.have.property("route");
+         expect(res.body).to.have.property("status");
+         // propagate the test block to delete the created assign using its id.
+             chai
+               .request(index)
+               .delete(`/api/v1/assign/${res.body.route[0].id}`)
+               .send()
+               .end((err, res) => {
+                 if (err) return done(err);
+                 expect(res).to.have.status([202]);
+                 expect(res.body).to.have.property("message");
+                 return done();
+               });
+           });
+       });
+   });
+
+describe("GET API /api/v1/assign", () => {
+  it("Should return error message assign", (done) => {
+    chai
+      .request(index)
+      .get(`/api/v1/assigns`)
+      .send()
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res).to.have.status([404]);
+        return done();
+      });
+  });
+  it("Should return all assigned", (done) => {
+    chai
+      .request(index)
+      .get("/api/v1/assign")
+      .send()
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res).to.have.status([200]);
+        expect(res.body).to.have.property("status");
+        expect(res.body).to.have.property("results");
+        expect(res.body).to.have.property("assigned");
+        return done();
+      });
+  });
+});
+
+describe("DELETE API /api/v1/route/{:id}", () => {
+  });
+  it("Should return error message on deleting with invalid id provided", (done) => {
+    chai
+      .request(index)
+      .delete(`/api/v1/assign/${"num"}`)
+      .send()
+      .end((err, res) => {
+        if (err) return done(err);
+        expect(res).to.have.status(404);
+        expect(res.body).to.have.property("status");
+        return done();
+      });
+  });

--- a/src/validations/index.js
+++ b/src/validations/index.js
@@ -22,7 +22,16 @@ export const routeValidation = (data) => {
     destination: Joi.string().min(3).required(),
     description: Joi.string().min(3).required(),
   });
+  return schema.validate(data);
+}
 
+// New assign validation
+export const assignValidation = (data) => {
+  const schema = Joi.object({
+    route: Joi.string().min(3).required(),
+    driver_name: Joi.string().min(3).required(),
+    plate_number: Joi.string().min(3).required(),
+  });
   return schema.validate(data);
 }
 // New update bus validation


### PR DESCRIPTION
## What does this PR do?
Create, read and delete assignement *"assign driver to bus"*
## Description of Task to be completed?
As an operator, I want to assign a driver to a bus, so that they can control it.

-  The operator should be able to assign a driver to a bus. 
-  The operator should be able to view a paginated list of driver to bus assignments
-  The driver should receive a bus assignment and unassignment email & in-app notifications.
-  Appropriate error messages are displayed on unsuccessful attempts

## How should this be manually tested?
`Clone the repo`
`checkout` to branch `ft-assign-driver-buses-12`
pull the changes by `git pull`
install all packages by running `npm install`
start app by `running npm run start:dev`
In your API testing tool (**postman** is recommended for that) call API

- Method: GET http://localhost:5000/api/v1/assign/ to `view/read` all *assigned* drivers.
- Method: POST http://localhost:5000/api/v1/assign/ to `create/register` new assign
- Method: DELETE http://localhost:5000/api/v1/assign/{id} to `delete` one specific assigned

## Any background context you want to provide?
Note that you should send the request with *route* , *driver_name* and *plate_number*  for **creating** new **assign** in the request body

- Format : 
` {
   "route":"Mulindi - Remera",
   "driver_name":"Kimironko",
   "plate_number":"RAB 1230 V"
 }`
## What are the relevant pivotal tracker stories?
[Trello Board](https://trello.com/c/RxZRNUCy/12-assign-drivers-to-buses)

Screenshots (if appropriate)
N/A

Questions:
N/A